### PR TITLE
fix(tenx): render git-token Secret whenever init container mounts it

### DIFF
--- a/charts/fluent-bit/templates/secret-tenx.yaml
+++ b/charts/fluent-bit/templates/secret-tenx.yaml
@@ -9,7 +9,16 @@ type: Opaque
 data:
   api-key: {{ .Values.tenx.apiKey | b64enc | quote }}
 {{- end }}
-{{- if and .Values.tenx.enabled .Values.tenx.gitToken }}
+{{- /*
+    Render the git-token Secret whenever the tenx init container will
+    mount it — i.e. whenever tenx.enabled AND (config.git.enabled OR
+    symbols.git.enabled). A missing gitToken is valid for public repos;
+    rendering an empty-token Secret keeps the kubelet mount path happy
+    instead of crashing pods in FailedMount / CreateContainerConfigError.
+    Mirrors the gate used by $tenxGitInit in _pod.tpl.
+*/ -}}
+{{- $tenxGitInit := and .Values.tenx.enabled (or .Values.tenx.config.git.enabled .Values.tenx.symbols.git.enabled) -}}
+{{- if $tenxGitInit }}
 {{- if and .Values.tenx.apiKey (ne .Values.tenx.apiKey "NO-API-KEY") }}
 ---
 {{- end }}
@@ -21,5 +30,5 @@ metadata:
     {{- include "fluent-bit.labels" . | nindent 4 }}
 type: Opaque
 data:
-  token: {{ .Values.tenx.gitToken | b64enc | quote }}
+  token: {{ .Values.tenx.gitToken | default "" | b64enc | quote }}
 {{- end }}

--- a/charts/fluentd/templates/secret-tenx.yaml
+++ b/charts/fluentd/templates/secret-tenx.yaml
@@ -9,7 +9,14 @@ type: Opaque
 data:
   api-key: {{ .Values.tenx.apiKey | b64enc | quote }}
 {{- end }}
-{{- if and .Values.tenx.enabled .Values.tenx.gitToken }}
+{{- /*
+    Render the git-token Secret whenever the tenx init container will
+    mount it. A missing gitToken is valid for public repos; rendering
+    an empty-token Secret keeps pods from hanging in
+    CreateContainerConfigError / FailedMount.
+*/ -}}
+{{- $tenxGitInit := and .Values.tenx.enabled (or .Values.tenx.config.git.enabled .Values.tenx.symbols.git.enabled) -}}
+{{- if $tenxGitInit }}
 {{- if and .Values.tenx.apiKey (ne .Values.tenx.apiKey "NO-API-KEY") }}
 ---
 {{- end }}
@@ -21,5 +28,5 @@ metadata:
     {{- include "fluentd.labels" . | nindent 4 }}
 type: Opaque
 data:
-  token: {{ .Values.tenx.gitToken | b64enc | quote }}
+  token: {{ .Values.tenx.gitToken | default "" | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Summary

Fix so the `tenx-git-token` Secret renders whenever the init container will mount it, not only when the token value is truthy.

## The bug

The init container in `_pod.tpl` unconditionally mounts the `<release>-tenx-git-token` Secret when `tenx.enabled && (config.git.enabled || symbols.git.enabled)`. But `secret-tenx.yaml` only rendered the Secret when `tenx.gitToken` was set. A missing token (valid for public repos) caused pods to hang in `CreateContainerConfigError` / `FailedMount`.

## Fix

Gate the Secret render on the same condition the init container uses. Default token to empty string.

Affects fluent-bit and fluentd charts.

Generated with Claude Code.
