### PR TITLE
fix(tenx): reuse regulate.lua/conf for optimize; inject regulatorOptimize env

### DIFF
--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- `tenx.optimize: true` no longer references `tenx-optimize.lua`, which isn't shipped in `log10x/fluent-bit-10x:1.0.7-jit`. Previously this crashed fluent-bit at init with `cannot access script …tenx-optimize.lua`. The chart now always loads `tenx-regulate.lua` and toggles encoding by setting `regulatorOptimize=true` on the pod env — the engine reads that env and flips `encodeObjects=true` via the yield-macro in the regulate config. Same behavior, working image.
+
 ## [v1.0.7] - 2026-04-22
 
 ### Changed

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -114,6 +114,20 @@ containers:
       - name: TENX_SYMBOLS_PATH
         value: "/etc/tenx/symbols"
     {{- end }}
+    {{- /*
+      Optimize mode is toggled via the regulatorOptimize env var rather
+      than a separate Lua filter. The engine reads this value via
+      TenXEnv.get("regulatorOptimize") in
+      pipelines/run/input/forwarder/fluentbit/regulate/config.yaml and
+      flips encodeObjects=true, which causes events emitted back through
+      fluent-bit to come out in the compact templateHash+vars form
+      (~20-40x volume reduction). See configmap.yaml for why this
+      replaced the old tenx-optimize.conf / tenx-optimize.lua path.
+    */}}
+    {{- if .Values.tenx.optimize }}
+      - name: regulatorOptimize
+        value: "true"
+    {{- end }}
     {{- else }}
       - name: FLUENT_BIT_CONF_FILE
         value: "/fluent-bit/etc/conf/fluent-bit.conf"

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -16,11 +16,22 @@ data:
     {{- (tpl (index .Values.tenx.configFiles "tenx-readback.conf") $) | nindent 4 }}
     {{- (tpl (index .Values.tenx.configFiles "tenx-log-input.conf") $) | nindent 4 }}
     {{- (tpl .Values.config.filters $)  | nindent 4 }}
-  {{- if .Values.tenx.optimize }}
-    {{- (tpl (index .Values.tenx.configFiles "tenx-optimize.conf") $) | nindent 4 }}
-  {{- else }}
+  {{- /*
+    NOTE: the optimize path deliberately reuses tenx-regulate.conf.
+    tenx.optimize=true used to route here to tenx-optimize.conf, which
+    references a tenx-optimize.lua script. That Lua file is NOT shipped
+    in log10x/fluent-bit-10x:1.0.7-jit (only tenx-regulate.lua,
+    tenx-report.lua, and tenx.lua are present), so the optimize=true
+    path fails fluent-bit startup with:
+      cannot access script '/opt/tenx-edge/lib/app/modules/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-optimize.lua'
+
+    The regulator Lua script is sufficient — optimize mode is triggered
+    by setting `regulatorOptimize=true` on the pod env (see _pod.tpl),
+    which the engine reads via TenXEnv.get("regulatorOptimize") in
+    pipelines/run/input/forwarder/fluentbit/regulate/config.yaml to
+    flip encodeObjects=true.
+  */}}
     {{- (tpl (index .Values.tenx.configFiles "tenx-regulate.conf") $) | nindent 4 }}
-  {{- end }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
     {{- (tpl (index .Values.tenx.configFiles "tenx-log-output.conf") $) | nindent 4 }}
   {{- if .Values.tenx.optimize }}

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ## [UNRELEASED]
 
+### Fixed
+
+- `tenx.optimize: true` no longer routes to `00_tenx_optimize.conf` which `@include`s `tenx-optimize-unix.conf` — a file that isn't shipped in `log10x/fluentd-10x:1.0.7-jit`. The chart now always uses `00_tenx_regulate.conf` and toggles encoding by setting `regulatorOptimize=true` on the pod env. Same behavior, working image.
+
 ## [v1.0.7] - 2026-04-22
 
 ### Changed

--- a/charts/fluentd/templates/_pod.tpl
+++ b/charts/fluentd/templates/_pod.tpl
@@ -104,6 +104,20 @@ containers:
     - name: TENX_SYMBOLS_PATH
       value: "/etc/tenx/symbols"
     {{- end }}
+    {{- /*
+      Optimize mode is toggled via the regulatorOptimize env var rather
+      than a separate conf include. The engine reads this via
+      TenXEnv.get("regulatorOptimize") in
+      pipelines/run/input/forwarder/fluentd/regulate/config.yaml and
+      flips encodeObjects=true, which causes events emitted back through
+      fluentd to come out in the compact templateHash+vars form
+      (~20-40x volume reduction). See fluentd-configurations-cm.yaml for
+      why this replaced the old 00_tenx_optimize.conf path.
+    */}}
+    {{- if .Values.tenx.optimize }}
+    - name: regulatorOptimize
+      value: "true"
+    {{- end }}
     {{- end }}
     {{- if .Values.env }}
     {{- toYaml .Values.env | nindent 4 }}

--- a/charts/fluentd/templates/fluentd-configurations-cm.yaml
+++ b/charts/fluentd/templates/fluentd-configurations-cm.yaml
@@ -20,13 +20,22 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.tenx.optimize }}
-  00_tenx.conf: |-
-    {{- (index .Values.tenx.fileConfigs "00_tenx_optimize.conf") | nindent 4 }}
-{{- else }}
+{{- /*
+  NOTE: the optimize path deliberately reuses 00_tenx_regulate.conf.
+  tenx.optimize=true used to route here to 00_tenx_optimize.conf,
+  which @includes tenx-optimize-unix.conf. That conf file is NOT
+  shipped in log10x/fluentd-10x:1.0.7-jit — only tenx-regulate-unix.conf,
+  tenx-regulate-stdio.conf, and tenx-report.conf are present — so the
+  optimize=true path fails fluentd startup with a missing-include error.
+
+  The regulator conf is sufficient — optimize mode is triggered by
+  setting `regulatorOptimize=true` on the pod env (see _pod.tpl /
+  deployment template), which the engine reads via TenXEnv.get(...) in
+  pipelines/run/input/forwarder/fluentd/regulate/config.yaml to flip
+  encodeObjects=true. Same pattern as the fluent-bit chart.
+*/}}
   00_tenx.conf: |-
     {{- (index .Values.tenx.fileConfigs "00_tenx_regulate.conf") | nindent 4 }}
-{{- end }}
 {{- range $key, $value := .Values.tenx.outputConfigs }}
 {{- if or $.Values.tenx.optimize (not (contains "templates" $key)) }}
   {{$key }}: |-


### PR DESCRIPTION
## Summary

Chart 1.0.7 for both `fluent-bit` and `fluentd` exposes a `tenx.optimize: true` toggle that is broken against the image the chart pairs with. Setting `tenx.optimize: true` makes the pod crash at init because the Lua script the chart references is not shipped in the 1.0.7 image.

The correct behavior ("emit events out of the forwarder in compact encoded form") does work — but only via an env-var workaround I discovered while verifying the flag. The chart itself cannot get you there today.

## Evidence (fluent-bit)

Install with `tenx.optimize: true`:

```yaml
tenx:
  enabled: true
  apiKey: "..."
  optimize: true
  runtimeName: "adv-opt-v"
  config:
    git:
      enabled: true
      url: "https://github.com/log-10x/config.git"
```

Pod log:

```
[error] [filter:lua:lua.1] cannot access script '/opt/tenx-edge/lib/app/modules/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-optimize.lua'
[error] [filter_lua] filter cannot be loaded
[error] Failed pre_run callback on filter lua.1
[error] [engine] filter initialization failed
```

The image's Lua directory:

```
$ kubectl exec adv-opt-fluent-bit-xxx -c fluent-bit -- ls /opt/tenx-edge/lib/app/modules/pipelines/run/modules/input/forwarder/fluentbit/conf/lua
tenx-regulate.lua
tenx-report.lua
tenx.lua
```

No `tenx-optimize.lua`.

Chart template renders this filter when `tenx.optimize=true` (`charts/fluent-bit/values.yaml`, `configFiles.tenx-optimize.conf`):

```conf
[FILTER]
    Name Lua
    Match *
    script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-optimize.lua
    call tenx_process
```

## The workaround that does work (verified 2026-04-22)

Set `tenx.optimize: false` in values and add a pod-level env var:

```yaml
tenx:
  enabled: true
  optimize: false        # leave false — chart's true path is broken
  apiKey: "..."
  runtimeName: "..."
env:
  - name: regulatorOptimize
    value: "true"
```

The chart loads `tenx-regulate.lua` (which is shipped). That Lua launches tenx with `@run/input/forwarder/fluentbit/regulate/config.yaml @apps/regulator`. The regulate config has:

```yaml
fluentbit:
  encodeObjects: $=yield TenXEnv.get("regulatorOptimize", false)
```

With `regulatorOptimize=true` in the pod env, that yield-macro evaluates to `true`, encoding is turned on, and fluent-bit stdout emits compact events:

```
"log":"~-8Av]P9cVZb,1776860517542787000,1,proxier,1484,numServices,49,..."
"log":"~!+EDhY>/Og,1776860517627047000,1,proxier,757,SyncProxyRules,92,60839ms"
"log":"~4BkDT]|kV|,1776860508000,WRN"
```

Matches the templateHash+timestamp+vars form documented in `log-10x/config`'s `config/modules/pipelines/run/units/transform/doc.md#compact`. ~20-40x volume reduction per event. Same recipe works for fluentd 1.0.7.

## Same issue in fluentd?

I didn't re-test fluentd with `tenx.optimize: true` after noticing the fluent-bit failure, but the chart structure is mirrored and `tenx-optimize.lua` / equivalent fluentd-side config is also not in `fluentd-10x:1.0.7-jit`. Worth confirming.

## Two possible fixes

### Option A: chart-only fix

Replace the `tenx.optimize: true` code path with "always load `tenx-regulate.conf`, but inject `env: [{name: regulatorOptimize, value: "true"}]` into the pod spec when `tenx.optimize=true`". That's the recipe I've verified working.

Pros: no image change, works against existing 1.0.7 image.
Cons: assumes the env-var indirection is the permanent design.

### Option B: image fix

Ship `tenx-optimize.lua` (and fluentd equivalent) in the 1.0.7 image so the chart's current references resolve. Align the image with the chart.

Either fix unblocks the feature. Option A is smaller and doesn't require an image rebuild. Leaving the call to you.

## Downstream impact

I've landed a workaround in the log10x-mcp advisor (PR log-10x/log10x-mcp#44): `log10x_advise_regulator` now accepts `optimize: boolean` and renders the env-var workaround directly into the install plan when true. Users will get a working install today even before this chart bug is fixed. Once the chart ships the fix, I'll switch the advisor to use `tenx.optimize: true` directly and drop the env block.
