### PR TITLE
refactor(charts): rename regulator → reducer (fluentd + fluent-bit 1.0.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release Status](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml/badge.svg?branch=main)](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml)
 
-Helm charts for deploying Fluentd / Fluent-Bit with the 10x [Regulator](https://doc.log10x.com/apps/regulator/) app
+Helm charts for deploying Fluentd / Fluent-Bit with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
 
 The Fluentd and Fluent-Bit charts are built on top of the official [fluent helm charts](https://github.com/fluent/helm-charts), and work by replacing the base image with one which has [10x installed](https://doc.log10x.com/install/linux/) on it, as well as setting all the necessary [10x configuration](https://doc.log10x.com/run/input/forwarder/)
 

--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -22,8 +22,8 @@
 
 ### Removed
 
-- Removed `tenx.kind` option (report/regulate/optimize) — chart is now hardcoded to regulator mode
-- Removed reporter and optimizer Lua scripts and config entries — use regulator with `tenx.optimize=true` for optimization
+- Removed `tenx.kind` option (report/regulate/optimize) — chart is now hardcoded to reducer mode
+- Removed reporter and optimizer Lua scripts and config entries — use reducer with `tenx.optimize=true` for optimization
 
 ### Added
 

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - logging
   - fluent
   - fluent-bit
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.0.7
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
@@ -23,8 +23,8 @@ annotations:
     - kind: changed
       description: "Upgraded 10x engine to version 1.0.7"
     - kind: removed
-      description: "Removed tenx.kind option (report/regulate/optimize) — chart is now hardcoded to regulator mode"
+      description: "Removed tenx.kind option (report/regulate/optimize) — chart is now hardcoded to reducer mode"
     - kind: added
       description: "Added tenx.optimize flag (default false) to enable optimization mode (lossless event compaction)"
     - kind: removed
-      description: "Removed reporter and optimizer Lua scripts and config entries — use regulator with tenx.optimize=true for optimization"
+      description: "Removed reporter and optimizer Lua scripts and config entries — use reducer with tenx.optimize=true for optimization"

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This chart is intended to set up a Fluent Bit daemonset with the 10x [Regulator](https://doc.log10x.com/apps/regulator/) app
+This chart is intended to set up a Fluent Bit daemonset with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
 
 The chart is derived from the base [Fluent Bit chart](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit), with some key differences which enable Fluent Bit to work with 10x:
 
@@ -34,7 +34,7 @@ helm install fluent-bit log10x-fluent/fluent-bit
 
 ## Examples
 
-Sample values.yaml files for deploying Fluent Bit with the 10x [Regulator](https://doc.log10x.com/apps/regulator/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
+Sample values.yaml files for deploying Fluent Bit with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
 
 Full details on the base Fluent Bit chart can be found at the [original repo](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit)
 
@@ -62,7 +62,7 @@ Specifies the 10x distribution. Options: `jit` (default), `native`. For more det
 Your 10x API key for metrics reporting. Default: `"NO-API-KEY"`
 
 ### tenx.optimize
-Enable optimization mode to losslessly compact events for 50-65% volume reduction. Default: `false`. When disabled, the regulator filters events but emits them in their original form.
+Enable optimization mode to losslessly compact events for 50-65% volume reduction. Default: `false`. When disabled, the reducer filters events but emits them in their original form.
 
 ### tenx.gitToken
 Git access token for fetching config/symbols from private Git repositories. Works with any Git provider (GitHub, GitLab, Bitbucket, self-hosted). When set, a Kubernetes Secret is created and injected via `secretKeyRef`.

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -34,8 +34,8 @@ tenx:
   apiKey: "NO-API-KEY"
 
   # Enable optimization mode to encode emitted events for volume reduction.
-  # When false (default), the regulator filters events but emits them in their original form.
-  # When true, the regulator also losslessly compacts surviving events (50-65% volume reduction).
+  # When false (default), the reducer filters events but emits them in their original form.
+  # When true, the reducer also losslessly compacts surviving events (50-65% volume reduction).
   optimize: false
 
   # Specify name for the 10x runtime
@@ -100,7 +100,7 @@ tenx:
     tenx-readback.conf: |
       @INCLUDE /opt/tenx-edge/lib/app/modules/pipelines/run/modules/input/forwarder/fluentbit/conf/tenx-unix.conf
 
-    # Setting up the 10x regulator pipeline as a Lua filter.
+    # Setting up the 10x reducer pipeline as a Lua filter.
     #
     # https://github.com/log-10x/modules/blob/main/pipelines/run/modules/input/forwarder/fluentbit/conf/tenx-regulate.conf
     #
@@ -111,7 +111,7 @@ tenx:
           script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-regulate.lua
           call tenx_process
 
-    # Setting up the 10x optimizer pipeline as a Lua filter (regulator with optimization enabled).
+    # Setting up the 10x optimizer pipeline as a Lua filter (reducer with optimization enabled).
     # Used when tenx.optimize is true.
     #
     tenx-optimize.conf: |

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -22,8 +22,8 @@
 
 ### Removed
 
-- Removed `tenx.kind` option (report/regulate/optimize) — chart is now hardcoded to regulator mode
-- Removed reporter and optimizer fluentd conf entries — use regulator with `tenx.optimize=true` for optimization
+- Removed `tenx.kind` option (report/regulate/optimize) — chart is now hardcoded to reducer mode
+- Removed reporter and optimizer fluentd conf entries — use reducer with `tenx.optimize=true` for optimization
 
 ### Added
 

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - fluent
   - fluentd
 # type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.0.7
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
@@ -25,8 +25,8 @@ annotations:
     - kind: changed
       description: "Upgraded 10x engine to version 1.0.7"
     - kind: removed
-      description: "Removed tenx.kind option (report/regulate/optimize) — chart is now hardcoded to regulator mode"
+      description: "Removed tenx.kind option (report/regulate/optimize) — chart is now hardcoded to reducer mode"
     - kind: added
       description: "Added tenx.optimize flag (default false) to enable optimization mode (lossless event compaction)"
     - kind: removed
-      description: "Removed reporter and optimizer fluentd conf entries — use regulator with tenx.optimize=true for optimization"
+      description: "Removed reporter and optimizer fluentd conf entries — use reducer with tenx.optimize=true for optimization"

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This chart is intended to set up a Fluentd daemonset with the 10x [Regulator](https://doc.log10x.com/apps/regulator/) app
+This chart is intended to set up a Fluentd daemonset with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
 
 The chart is derived from the base [Fluentd chart](https://github.com/fluent/helm-charts/tree/main/charts/fluentd), with some key differences which enable Fluentd to work with 10x:
 
@@ -34,7 +34,7 @@ helm install fluentd log10x-fluent/fluentd
 
 ## Examples
 
-Sample values.yaml files for deploying Fluentd with the 10x [Regulator](https://doc.log10x.com/apps/regulator/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
+Sample values.yaml files for deploying Fluentd with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
 
 Full details on the base Fluentd chart can be found at the [original repo](https://github.com/fluent/helm-charts/tree/main/charts/fluentd)
 

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -33,8 +33,8 @@ tenx:
   apiKey: "NO-API-KEY"
 
   # Enable optimization mode to encode emitted events for volume reduction.
-  # When false (default), the regulator filters events but emits them in their original form.
-  # When true, the regulator also losslessly compacts surviving events (50-65% volume reduction).
+  # When false (default), the reducer filters events but emits them in their original form.
+  # When true, the reducer also losslessly compacts surviving events (50-65% volume reduction).
   optimize: false
 
   # Specify name for the 10x runtime
@@ -119,7 +119,7 @@ tenx:
   #
   fileConfigs:
     # Fluentd config for passing events into the 10x pipeline via Unix socket.
-    # When optimize is true, uses the optimize conf which adds regulatorOptimize flag.
+    # When optimize is true, uses the optimize conf which adds reducerOptimize flag.
     #
     00_tenx_regulate.conf: |-
       @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-regulate-unix.conf"
@@ -127,7 +127,7 @@ tenx:
     00_tenx_optimize.conf: |-
       @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-optimize-unix.conf"
 
-    # Controls which events are emitted into the 10x regulator.
+    # Controls which events are emitted into the 10x reducer.
     # Works by applying the @TENX label.
     #
     # Events which aren't meant to be regulated should have the @FINAL-OUTPUT label applied instead.

--- a/samples/fluentbit-optimize.yaml
+++ b/samples/fluentbit-optimize.yaml
@@ -1,10 +1,10 @@
-# Sample values.yaml for deploying an 10x regulator with fluent-bit
+# Sample values.yaml for deploying an 10x reducer with fluent-bit
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the config.output, tenx-log-output.conf and tenx-templates-output.conf sections.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/regulator/deploy/#fluent-bit
+# https://doc.log10x.com/apps/reducer/deploy/#fluent-bit
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"

--- a/samples/fluentbit-regulate.yaml
+++ b/samples/fluentbit-regulate.yaml
@@ -1,16 +1,16 @@
-# Sample values.yaml for deploying an 10x regulator with fluent-bit
+# Sample values.yaml for deploying an 10x reducer with fluent-bit
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the config.output and tenx-log-output.conf sections.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/regulator/deploy/#fluent-bit
+# https://doc.log10x.com/apps/reducer/deploy/#fluent-bit
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"
 
 
-  runtimeName: "my-fluent-bit-regulator"
+  runtimeName: "my-fluent-bit-reducer"
 
   configFiles:
     # Edit this section to change which events to pass to 10x to regulate.

--- a/samples/fluentd-optimize.yaml
+++ b/samples/fluentd-optimize.yaml
@@ -1,10 +1,10 @@
-# Sample values.yaml for deploying an 10x regulator with optimization with fluentd
+# Sample values.yaml for deploying an 10x reducer with optimization with fluentd
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the outputConfigs section.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/regulator/deploy/#fluentd
+# https://doc.log10x.com/apps/reducer/deploy/#fluentd
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"

--- a/samples/fluentd-regulate.yaml
+++ b/samples/fluentd-regulate.yaml
@@ -1,16 +1,16 @@
-# Sample values.yaml for deploying an 10x regulator with fluentd
+# Sample values.yaml for deploying an 10x reducer with fluentd
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the outputConfigs section.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/regulator/deploy/#fluentd
+# https://doc.log10x.com/apps/reducer/deploy/#fluentd
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"
 
 
-  runtimeName: "my-fluentd-regulator"
+  runtimeName: "my-fluentd-reducer"
 
   fileConfigs:
     regulate:


### PR DESCRIPTION
## Summary
- regulator → reducer in values.yaml + CHANGELOGs
- regulatorOptimize → reducerOptimize
- Chart versions: fluentd 1.0.7 → 1.0.8, fluent-bit 1.0.7 → 1.0.8
- tenx-regulate.{conf,lua} filenames preserved (action verb)

Companion to log-10x/modules#21, log-10x/config#20, log-10x/mksite#26, log-10x/elastic-helm-charts#9, log-10x/opentelemetry-helm-charts#9, log-10x/docker-images#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)