### PR TITLE
fix: add v1.0.8 CHANGELOG entries for fluentd + fluent-bit

### DIFF
--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v1.0.8] - 2026-04-25
+
+### Changed
+
+- Renamed regulator to reducer (cosmetic) — `regulatorOptimize` env → `reducerOptimize`. Pipeline action verb `regulate` and config filenames preserved. Companion to log-10x/modules#21 and log-10x/config#20.
+
 ## [v1.0.7] - 2026-04-22
 
 ### Changed

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ## [UNRELEASED]
 
+## [v1.0.8] - 2026-04-25
+
+### Changed
+
+- Renamed regulator to reducer (cosmetic) — `regulatorOptimize` env → `reducerOptimize`. Pipeline action verb `regulate` and config filenames preserved. Companion to log-10x/modules#21 and log-10x/config#20.
+
 ## [v1.0.7] - 2026-04-22
 
 ### Changed


### PR DESCRIPTION
Release workflow's `Get changelog entry` step requires a v1.0.8 section in each chart's CHANGELOG.md to publish the chart. PR #9 bumped versions but didn't add changelog entries — this adds them so chart-releaser can publish 1.0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)