### PR TITLE
feat: rename Reducer to Receiver in chart prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release Status](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml/badge.svg?branch=main)](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml)
 
-Helm charts for deploying Fluentd / Fluent-Bit with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
+Helm charts for deploying Fluentd / Fluent-Bit with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) app
 
 The Fluentd and Fluent-Bit charts are built on top of the official [fluent helm charts](https://github.com/fluent/helm-charts), and work by replacing the base image with one which has [10x installed](https://doc.log10x.com/install/linux/) on it, as well as setting all the necessary [10x configuration](https://doc.log10x.com/run/input/forwarder/)
 

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This chart is intended to set up a Fluent Bit daemonset with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
+This chart is intended to set up a Fluent Bit daemonset with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) app
 
 The chart is derived from the base [Fluent Bit chart](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit), with some key differences which enable Fluent Bit to work with 10x:
 
@@ -34,7 +34,7 @@ helm install fluent-bit log10x-fluent/fluent-bit
 
 ## Examples
 
-Sample values.yaml files for deploying Fluent Bit with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
+Sample values.yaml files for deploying Fluent Bit with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
 
 Full details on the base Fluent Bit chart can be found at the [original repo](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit)
 

--- a/charts/fluentd/README.md
+++ b/charts/fluentd/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This chart is intended to set up a Fluentd daemonset with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) app
+This chart is intended to set up a Fluentd daemonset with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) app
 
 The chart is derived from the base [Fluentd chart](https://github.com/fluent/helm-charts/tree/main/charts/fluentd), with some key differences which enable Fluentd to work with 10x:
 
@@ -34,7 +34,7 @@ helm install fluentd log10x-fluent/fluentd
 
 ## Examples
 
-Sample values.yaml files for deploying Fluentd with the 10x [Reducer](https://doc.log10x.com/apps/reducer/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
+Sample values.yaml files for deploying Fluentd with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) can be found [here](https://github.com/log-10x/fluent-helm-charts/tree/main/samples). Set `tenx.optimize: true` to enable optimization mode for lossless event compaction.
 
 Full details on the base Fluentd chart can be found at the [original repo](https://github.com/fluent/helm-charts/tree/main/charts/fluentd)
 

--- a/samples/fluentbit-optimize.yaml
+++ b/samples/fluentbit-optimize.yaml
@@ -4,7 +4,7 @@
 # in the config.output, tenx-log-output.conf and tenx-templates-output.conf sections.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/reducer/deploy/#fluent-bit
+# https://doc.log10x.com/apps/receiver/deploy/#fluent-bit
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"

--- a/samples/fluentbit-regulate.yaml
+++ b/samples/fluentbit-regulate.yaml
@@ -4,7 +4,7 @@
 # in the config.output and tenx-log-output.conf sections.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/reducer/deploy/#fluent-bit
+# https://doc.log10x.com/apps/receiver/deploy/#fluent-bit
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"

--- a/samples/fluentd-optimize.yaml
+++ b/samples/fluentd-optimize.yaml
@@ -4,7 +4,7 @@
 # in the outputConfigs section.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/reducer/deploy/#fluentd
+# https://doc.log10x.com/apps/receiver/deploy/#fluentd
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"

--- a/samples/fluentd-regulate.yaml
+++ b/samples/fluentd-regulate.yaml
@@ -4,7 +4,7 @@
 # in the outputConfigs section.
 #
 # For more info on deploying, see -
-# https://doc.log10x.com/apps/reducer/deploy/#fluentd
+# https://doc.log10x.com/apps/receiver/deploy/#fluentd
 #
 tenx:
   license: "<YOUR-10X-LICENSE-HERE>"


### PR DESCRIPTION
Companion to log-10x/modules#32 + log-10x/config#28. Charts already supported read-only mode via tenx.readOnly. Updates prose and values comments to reflect new app name. Functionality unchanged. Engine options + conf filenames preserved.