### PR TITLE
chore: bump fluentd + fluent-bit charts to 1.0.16 (engine release with receiver app)

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - logging
   - fluent
   - fluent-bit
-version: 1.0.13
-appVersion: 1.0.13
+version: 1.0.16
+appVersion: 1.0.16
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - fluent
   - fluentd
 # type: application
-version: 1.0.13
-appVersion: 1.0.13
+version: 1.0.16
+appVersion: 1.0.16
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:


### PR DESCRIPTION
Engine 1.0.16 published today bundling apps/receiver. Charts bumped to pull the new images.