### PR TITLE
chore: bump fluentd + fluent-bit charts to engine 1.0.17

### DIFF
--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - logging
   - fluent
   - fluent-bit
-version: 1.0.16
-appVersion: 1.0.16
+version: 1.0.17
+appVersion: 1.0.17
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - fluent
   - fluentd
 # type: application
-version: 1.0.16
-appVersion: 1.0.16
+version: 1.0.17
+appVersion: 1.0.17
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:


### PR DESCRIPTION
Engine 1.0.16 had stale modules (pre-#34). 1.0.17 includes the modules#34 fix. Charts should ship latest.