### PR TITLE
chore: rename to receive/Receiver across chart values and samples

### DIFF
--- a/charts/fluent-bit/CHANGELOG.md
+++ b/charts/fluent-bit/CHANGELOG.md
@@ -14,6 +14,13 @@
 
 ## [UNRELEASED]
 
+## [v1.0.20] - 2026-05-06
+
+### Changed
+
+- Chart values use tenx-receive.conf and tenx-receive.lua paths into the Receiver modules tree. Default mode emits the Prometheus tenx_app=receiver label.
+- Sample values file is fluentbit-receive.yaml for the default filter mode.
+
 ## [v1.0.19] - 2026-05-02
 
 ### Changed

--- a/charts/fluent-bit/Chart.yaml
+++ b/charts/fluent-bit/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - logging
   - fluent
   - fluent-bit
-version: 1.0.19
-appVersion: 1.0.19
+version: 1.0.20
+appVersion: 1.0.20
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:
@@ -21,6 +21,6 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Bumped engine appVersion to 1.0.19 with the Receiver app rename and renamed engine options. The chart now launches the engine with receiverOptimize and receiverReadOnly options (was reducerOptimize and reducerReadOnly)."
+      description: "Chart values use tenx-receive.conf and tenx-receive.lua paths into the Receiver modules tree. Default mode emits the Prometheus tenx_app=receiver label."
     - kind: changed
-      description: "Chart prose and values comments updated to reference Receiver instead of Reducer. The Prometheus label tenx_app value reducer is unchanged. No metric churn."
+      description: "Sample values file is fluentbit-receive.yaml for the default filter mode."

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -62,7 +62,7 @@ Specifies the 10x distribution. Options: `jit` (default), `native`. For more det
 Your 10x API key for metrics reporting. Default: `"NO-API-KEY"`
 
 ### tenx.optimize
-Enable optimization mode to losslessly compact events for 50-65% volume reduction. Default: `false`. When disabled, the reducer filters events but emits them in their original form.
+Enable optimization mode to losslessly compact events for 50-65% volume reduction. Default: `false`. When disabled, the Receiver filters events but emits them in their original form.
 
 ### tenx.gitToken
 Git access token for fetching config/symbols from private Git repositories. Works with any Git provider (GitHub, GitLab, Bitbucket, self-hosted). When set, a Kubernetes Secret is created and injected via `secretKeyRef`.

--- a/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/fluent-bit/templates/_pod.tpl
@@ -95,7 +95,7 @@ containers:
         value: {{ .Values.tenx.apiKey | quote }}
     {{- end }}
       - name: FLUENT_BIT_CONF_FILE
-        value: "/fluent-bit/etc/conf/tenx-main-regulate.conf"
+        value: "/fluent-bit/etc/conf/tenx-main-receive.conf"
     {{- if .Values.tenx.runtimeName }}
       - name: TENX_RUNTIME_NAME
         value: {{ .Values.tenx.runtimeName | quote }}

--- a/charts/fluent-bit/templates/configmap.yaml
+++ b/charts/fluent-bit/templates/configmap.yaml
@@ -23,7 +23,7 @@ data:
   {{- else if .Values.tenx.optimize }}
     {{- (tpl (index .Values.tenx.configFiles "tenx-optimize.conf") $) | nindent 4 }}
   {{- else }}
-    {{- (tpl (index .Values.tenx.configFiles "tenx-regulate.conf") $) | nindent 4 }}
+    {{- (tpl (index .Values.tenx.configFiles "tenx-receive.conf") $) | nindent 4 }}
   {{- end }}
     {{- (tpl .Values.config.outputs $)  | nindent 4 }}
     {{- (tpl (index .Values.tenx.configFiles "tenx-log-output.conf") $) | nindent 4 }}

--- a/charts/fluent-bit/values.yaml
+++ b/charts/fluent-bit/values.yaml
@@ -97,29 +97,26 @@ tenx:
   # These appear AFTER the fluent-bit inputs/filters/outputs defined in the 'config' section below.
   #
   configFiles:
-    # Setting up a unix socket input for reading back regulated/optimized events from 10x
+    # Unix socket input for reading filtered/optimized events back from 10x.
     #
-    # Using absolute include path and not utilizing ${TENX_MODULES} because currently fluent-bit
-    # can't resolve environment vars as part of @INCLUDE
-    #
-    # See https://github.com/fluent/fluent-bit/issues/2020
+    # Uses an absolute include path because fluent-bit's @INCLUDE does not
+    # expand environment variables. See https://github.com/fluent/fluent-bit/issues/2020
     #
     tenx-readback.conf: |
       @INCLUDE /opt/tenx-edge/lib/app/modules/pipelines/run/modules/input/forwarder/fluentbit/conf/tenx-unix.conf
 
-    # Setting up the 10x receiver pipeline as a Lua filter.
+    # 10x Receiver pipeline (default mode) — filters events as a Lua filter.
+    # https://github.com/log-10x/modules/blob/main/pipelines/run/modules/input/forwarder/fluentbit/conf/tenx-receive.conf
     #
-    # https://github.com/log-10x/modules/blob/main/pipelines/run/modules/input/forwarder/fluentbit/conf/tenx-regulate.conf
-    #
-    tenx-regulate.conf: |
+    tenx-receive.conf: |
       [FILTER]
           Name Lua
           Match *
-          script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-regulate.lua
+          script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-receive.lua
           call tenx_process
 
-    # Setting up the 10x optimizer pipeline as a Lua filter (receiver with optimization enabled).
-    # Used when tenx.optimize is true.
+    # 10x Receiver pipeline in optimize mode — filters and losslessly compacts events.
+    # Selected when tenx.optimize is true.
     #
     tenx-optimize.conf: |
       [FILTER]
@@ -128,9 +125,9 @@ tenx:
           script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-optimize.lua
           call tenx_process
 
-    # Setting up the 10x reporter pipeline as a Lua filter (receiver with read-only enabled).
-    # Used when tenx.readOnly is true — 10x is a passive observer; events flow through
-    # Fluent Bit unchanged. No return loop, no readback Unix socket.
+    # 10x Receiver pipeline in read-only mode — events flow through Fluent Bit unchanged
+    # while 10x observes and emits metrics. Selected when tenx.readOnly is true.
+    # No return loop and no readback Unix socket in this mode.
     #
     tenx-report.conf: |
       [FILTER]
@@ -139,7 +136,7 @@ tenx:
           script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-report.lua
           call tenx_process
 
-    # Setting and input for reading the internal 10x log, which fluent-bit can forward to the selected output (see below)
+    # Input for reading the internal 10x log so fluent-bit can forward it to the selected output below.
     #
     tenx-log-input.conf: |
       [INPUT]

--- a/charts/fluentd/CHANGELOG.md
+++ b/charts/fluentd/CHANGELOG.md
@@ -14,6 +14,13 @@
 
 ## [UNRELEASED]
 
+## [v1.0.20] - 2026-05-06
+
+### Changed
+
+- Chart values use 00_tenx_receive.conf paths into the Receiver modules tree (tenx-receive-unix.conf). Default mode emits the Prometheus tenx_app=receiver label.
+- Sample values file is fluentd-receive.yaml for the default filter mode.
+
 ## [v1.0.19] - 2026-05-02
 
 ### Changed

--- a/charts/fluentd/Chart.yaml
+++ b/charts/fluentd/Chart.yaml
@@ -8,8 +8,8 @@ keywords:
   - fluent
   - fluentd
 # type: application
-version: 1.0.19
-appVersion: 1.0.19
+version: 1.0.20
+appVersion: 1.0.20
 icon: https://raw.githubusercontent.com/log-10x/fluent-helm-charts/main/icon.png
 home: https://github.com/log-10x/fluent-helm-charts
 sources:
@@ -23,6 +23,6 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Bumped engine appVersion to 1.0.19 with the Receiver app rename and renamed engine options. The chart now launches the engine with receiverOptimize and receiverReadOnly options (was reducerOptimize and reducerReadOnly)."
+      description: "Chart values use 00_tenx_receive.conf paths into the Receiver modules tree (tenx-receive-unix.conf). Default mode emits the Prometheus tenx_app=receiver label."
     - kind: changed
-      description: "Chart prose and values comments updated to reference Receiver instead of Reducer. The Prometheus label tenx_app value reducer is unchanged. No metric churn."
+      description: "Sample values file is fluentd-receive.yaml for the default filter mode."

--- a/charts/fluentd/templates/fluentd-configurations-cm.yaml
+++ b/charts/fluentd/templates/fluentd-configurations-cm.yaml
@@ -36,7 +36,7 @@ data:
     {{- (index .Values.tenx.fileConfigs "04_outputs.conf") | nindent 4 }}
 {{- else }}
   00_tenx.conf: |-
-    {{- (index .Values.tenx.fileConfigs "00_tenx_regulate.conf") | nindent 4 }}
+    {{- (index .Values.tenx.fileConfigs "00_tenx_receive.conf") | nindent 4 }}
   04_outputs.conf: |-
     {{- (index .Values.tenx.fileConfigs "04_outputs.conf") | nindent 4 }}
 {{- end }}

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -125,28 +125,25 @@ tenx:
   # Config files used internally by the template to set up the fluentd configuration.
   #
   fileConfigs:
-    # Fluentd config for passing events into the 10x pipeline via Unix socket.
-    # When optimize is true, uses the optimize conf which adds receiverOptimize flag.
+    # 10x Receiver pipeline (default mode) — passes events into 10x via Unix socket
+    # for filtering. Optimize mode uses the variant below to also losslessly compact events.
     #
-    00_tenx_regulate.conf: |-
-      @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-regulate-unix.conf"
+    00_tenx_receive.conf: |-
+      @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-receive-unix.conf"
 
     00_tenx_optimize.conf: |-
       @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-optimize-unix.conf"
 
-    # Read-only / report mode. 10x is launched as a subprocess that ingests
-    # events for aggregation only — no return loop, no Unix socket source.
-    # The parallel @FINAL-OUTPUT route in 04_outputs_report.conf keeps the
-    # original Fluentd pipeline shipping events unchanged.
+    # Read-only mode. 10x runs as a subprocess that observes events for aggregation
+    # only — no return loop, no Unix socket source. The parallel @FINAL-OUTPUT route
+    # in 04_outputs_report.conf keeps the original Fluentd pipeline shipping events unchanged.
     00_tenx_report.conf: |-
       @include "#{ENV['TENX_MODULES']}/pipelines/run/modules/input/forwarder/fluentd/conf/tenx-report-unix.conf"
 
-    # Controls which events are emitted into the 10x receiver.
-    # Works by applying the @TENX label.
+    # Controls which events are passed to the 10x Receiver via the @TENX label.
+    # Events that should bypass 10x get the @FINAL-OUTPUT label instead.
     #
-    # Events which aren't meant to be regulated should have the @FINAL-OUTPUT label applied instead.
-    #
-    # Default behavior is to emit all events to 10x for regulating, edit this section to change.
+    # Default behavior passes all events to 10x. Edit this section to scope it down.
     #
     04_outputs.conf: |-
       <label @OUTPUT>
@@ -174,7 +171,7 @@ tenx:
         </match>
       </label>
 
-    # Routes all events coming back from 10x after being regulated to the final Fluentd output.
+    # Routes events emitted by 10x back to the final Fluentd output.
     #
     05_tenx_processed.conf: |-
       <label @TENX-PROCESSED>

--- a/samples/fluentbit-optimize.yaml
+++ b/samples/fluentbit-optimize.yaml
@@ -1,4 +1,4 @@
-# Sample values.yaml for deploying an 10x reducer with fluent-bit
+# Sample values.yaml for deploying an 10x receiver with fluent-bit
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the config.output, tenx-log-output.conf and tenx-templates-output.conf sections.
@@ -14,8 +14,7 @@ tenx:
   runtimeName: "my-fluent-bit-optimizer"
 
   configFiles:
-    # Edit this section to change which events to pass to 10x to optimize.
-    #
+    # Edit this section to scope which events the 10x Receiver compacts in optimize mode.
     # Defaults to passing all events to 10x.
     #
     tenx-optimize.conf: |

--- a/samples/fluentbit-receive.yaml
+++ b/samples/fluentbit-receive.yaml
@@ -1,4 +1,4 @@
-# Sample values.yaml for deploying an 10x reducer with fluent-bit
+# Sample values.yaml for deploying an 10x receiver with fluent-bit
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the config.output and tenx-log-output.conf sections.
@@ -10,18 +10,17 @@ tenx:
   license: "<YOUR-10X-LICENSE-HERE>"
 
 
-  runtimeName: "my-fluent-bit-reducer"
+  runtimeName: "my-fluent-bit-receiver"
 
   configFiles:
-    # Edit this section to change which events to pass to 10x to regulate.
-    #
+    # Edit this section to scope which events the 10x Receiver filters.
     # Defaults to passing all events to 10x.
     #
-    tenx-regulate.conf: |
+    tenx-receive.conf: |
       [FILTER]
           Name Lua
           Match *
-          script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-regulate.lua
+          script ${TENX_MODULES}/pipelines/run/modules/input/forwarder/fluentbit/conf/lua/tenx-receive.lua
           call tenx_process
 
     tenx-log-output.conf: |

--- a/samples/fluentd-optimize.yaml
+++ b/samples/fluentd-optimize.yaml
@@ -1,4 +1,4 @@
-# Sample values.yaml for deploying an 10x reducer with optimization with fluentd
+# Sample values.yaml for deploying an 10x receiver with optimization with fluentd
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the outputConfigs section.
@@ -14,32 +14,30 @@ tenx:
   runtimeName: "my-fluentd-optimizer"
 
   fileConfigs:
-    optimize:
-      # Edit this section to change which events to pass to 10x to optimize.
-      #
-      # Defaults to passing all events to 10x.
-      #
-      04_outputs.conf: |-
-        <label @OUTPUT>
-          <match **>
-            @type relabel
-            @label @TENX
-          </match>
-        </label>
-      #
-      # Example of only passing some events:
-      #
-      # 04_outputs.conf: |-
-      #   <label @OUTPUT>
-      #     <match Some.Tag.To.Optimize>
-      #       @type relabel
-      #       @label @TENX
-      #     </match>
-      #     <match **>
-      #       @type relabel
-      #       @label @FINAL-OUTPUT
-      #     </match>
-      #   </label>
+    # Edit this section to scope which events the 10x Receiver compacts in optimize mode.
+    # Defaults to passing all events to 10x.
+    #
+    04_outputs.conf: |-
+      <label @OUTPUT>
+        <match **>
+          @type relabel
+          @label @TENX
+        </match>
+      </label>
+    #
+    # Example of only passing some events:
+    #
+    # 04_outputs.conf: |-
+    #   <label @OUTPUT>
+    #     <match Some.Tag.To.Optimize>
+    #       @type relabel
+    #       @label @TENX
+    #     </match>
+    #     <match **>
+    #       @type relabel
+    #       @label @FINAL-OUTPUT
+    #     </match>
+    #   </label>
 
   outputConfigs:
     06_final_output.conf: |-

--- a/samples/fluentd-receive.yaml
+++ b/samples/fluentd-receive.yaml
@@ -1,4 +1,4 @@
-# Sample values.yaml for deploying an 10x reducer with fluentd
+# Sample values.yaml for deploying an 10x receiver with fluentd
 #
 # Make sure to add your 10x license, as well as setup your backend info
 # in the outputConfigs section.
@@ -10,35 +10,33 @@ tenx:
   license: "<YOUR-10X-LICENSE-HERE>"
 
 
-  runtimeName: "my-fluentd-reducer"
+  runtimeName: "my-fluentd-receiver"
 
   fileConfigs:
-    regulate:
-      # Edit this section to change which events to pass to 10x to regulate.
-      #
-      # Defaults to passing all events to 10x.
-      #
-      04_outputs.conf: |-
-        <label @OUTPUT>
-          <match **>
-            @type relabel
-            @label @TENX
-          </match>
-        </label>
-      #
-      # Example of only passing some events:
-      #
-      # 04_outputs.conf: |-
-      #   <label @OUTPUT>
-      #     <match Some.Tag.To.Regulate>
-      #       @type relabel
-      #       @label @TENX
-      #     </match>
-      #     <match **>
-      #       @type relabel
-      #       @label @FINAL-OUTPUT
-      #     </match>
-      #   </label>
+    # Edit this section to scope which events the 10x Receiver filters.
+    # Defaults to passing all events to 10x.
+    #
+    04_outputs.conf: |-
+      <label @OUTPUT>
+        <match **>
+          @type relabel
+          @label @TENX
+        </match>
+      </label>
+    #
+    # Example of only passing some events:
+    #
+    # 04_outputs.conf: |-
+    #   <label @OUTPUT>
+    #     <match Some.Tag.To.Filter>
+    #       @type relabel
+    #       @label @TENX
+    #     </match>
+    #     <match **>
+    #       @type relabel
+    #       @label @FINAL-OUTPUT
+    #     </match>
+    #   </label>
 
   outputConfigs:
     06_final_output.conf: |-


### PR DESCRIPTION
Bumps fluent-bit + fluentd charts to 1.0.20.

- Chart values config keys: tenx-receive.conf and 00_tenx_receive.conf drive the default Receiver filter mode. Optimize and report keys are unchanged.
- Lua and conf script paths in chart values point at the receive/ variants in the modules tree (tenx-receive.lua, tenx-receive-unix.conf).
- FLUENT_BIT_CONF_FILE in fluent-bit pod template points at tenx-main-receive.conf — matches the engine image entry config.
- Samples renamed: fluentbit-receive.yaml and fluentd-receive.yaml. fluentd sample fileConfigs flattened to match the chart's actual values structure (override 04_outputs.conf directly).
- Prose comments in chart values, README, and samples describe the Receiver and its filter / optimize / read-only modes in user terms.

Requires the engine image to ship the renamed config files (tenx-main-receive.conf, tenx-receive.conf, tenx-receive.lua, tenx-receive-unix.conf, tenx-receive-stdio.conf).