### PR TITLE
docs(readme): tag website links with GitHub-source UTMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ itself is open source, **using Log10x requires a commercial license**.
 
 **Get Started:**
 
-- [Log10x Pricing](https://log10x.com/pricing)
+- [Log10x Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=fluent-helm-charts&utm_content=footer)
 - [Documentation](https://doc.log10x.com)
 - [Contact Sales](mailto:sales@log10x.com)


### PR DESCRIPTION
Tags this repo's **www.log10x.com** README links with GitHub-source UTMs so traffic arriving from this repo's README is attributable per-repo in GA4/PostHog.

**Scheme:** `utm_source=github&utm_medium=readme&utm_campaign=fluent-helm-charts&utm_content=<location>`

Files:
- `README.md`

Display text is unchanged (UTMs hidden in rendered README). `doc.log10x.com`, `console.log10x.com`, and `mailto:` links are intentionally left untagged.

Part of a cross-repo pass to attribute GitHub-sourced website traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)