### PR TITLE
docs(readme): UTM-tag links + fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Release Status](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml/badge.svg?branch=main)](https://github.com/log-10x/fluent-helm-charts/actions/workflows/release.yaml)
 
-Helm charts for deploying Fluentd / Fluent-Bit with the 10x [Receiver](https://doc.log10x.com/apps/receiver/) app
+Helm charts for deploying Fluentd / Fluent-Bit with the [Log10x](https://www.log10x.com/?utm_source=github&utm_medium=readme&utm_campaign=fluent-helm-charts&utm_content=hero) [Receiver](https://doc.log10x.com/apps/receiver/) app
 
 The Fluentd and Fluent-Bit charts are built on top of the official [fluent helm charts](https://github.com/fluent/helm-charts), and work by replacing the base image with one which has [10x installed](https://doc.log10x.com/install/linux/) on it, as well as setting all the necessary [10x configuration](https://doc.log10x.com/run/input/forwarder/)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Fluentd and Fluent-Bit charts are built on top of the official [fluent helm 
 
 For more details on how the images are created, see the [docker-images repo](https://github.com/log-10x/docker-images).
 
-The supported [10x distributions](https://doc.log10x.com/architecture/flavors/) are JIT Edge and Native Edge. Check out each individual chart values.yaml for full configuration options.
+The supported [10x distributions](https://doc.log10x.com/engine/flavors/) are JIT Edge and Native Edge. Check out each individual chart values.yaml for full configuration options.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ itself is open source, **using Log10x requires a commercial license**.
 
 **Get Started:**
 
-- [Log10x Pricing](https://log10x.com/pricing)
+- [Log10x Pricing](https://www.log10x.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=fluent-helm-charts&utm_content=footer)
 - [Documentation](https://doc.log10x.com)
 - [Contact Sales](mailto:sales@log10x.com)

--- a/charts/fluent-bit/README.md
+++ b/charts/fluent-bit/README.md
@@ -56,7 +56,7 @@ The chart includes the following 10x-specific configuration options:
 Main switch to enable/disable 10x integration. Default: `true`
 
 ### tenx.variant
-Specifies the 10x distribution. Options: `jit` (default), `native`. For more details, see [10x Flavors](https://doc.log10x.com/architecture/flavors)
+Specifies the 10x distribution. Options: `jit` (default), `native`. For more details, see [10x Flavors](https://doc.log10x.com/engine/flavors)
 
 ### tenx.apiKey
 Your 10x API key for metrics reporting. Default: `"NO-API-KEY"`


### PR DESCRIPTION
This PR does two things to the README, both verified:

1. **UTM-tags** the www.log10x.com link(s) (`utm_source=github&utm_medium=readme&utm_campaign=fluent-helm-charts`) so GitHub-sourced traffic is attributable.
2. **Fixes broken doc.log10x.com links** (404s) by repointing to current, HTTP-verified pages:
   - `architecture/flavors` -> `engine/flavors` (README + fluent-bit chart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)